### PR TITLE
docs: fix Javadoc warnings

### DIFF
--- a/src/main/java/berlin/yuna/logic/CsvReader.java
+++ b/src/main/java/berlin/yuna/logic/CsvReader.java
@@ -52,7 +52,7 @@ public class CsvReader {
     }
 
     /**
-     * '{@link Stream}<{@link CsvRow}>' must be closed with 'try'-with-resources statement
+     * {@code Stream<CsvRow>} must be closed with a try-with-resources statement.
      * <p> The returned stream encapsulates a {@link Reader}. If timely
      * disposal of file system resources is required, the try-with-resources
      * construct should be used to ensure that the stream's

--- a/src/main/java/berlin/yuna/logic/StreamCSV.java
+++ b/src/main/java/berlin/yuna/logic/StreamCSV.java
@@ -12,7 +12,7 @@ import static berlin.yuna.logic.CsvReader.csvReader;
 public class StreamCSV {
 
     /**
-     * '{@link Stream}<{@link CsvRow}>' <b>must be closed with 'try'-with-resources statement</b>
+     * {@code Stream<CsvRow>} <b>must be closed with a try-with-resources statement.</b>
      * <p> The returned stream encapsulates a {@link Reader}.  If timely
      * disposal of file system resources is required, the try-with-resources
      * construct should be used to ensure that the stream's
@@ -29,7 +29,7 @@ public class StreamCSV {
     }
 
     /**
-     * '{@link Stream}<{@link CsvRow}>' <b>must be closed with 'try'-with-resources statement</b>
+     * {@code Stream<CsvRow>} <b>must be closed with a try-with-resources statement.</b>
      * <p> The returned stream encapsulates a {@link Reader}.  If timely
      * disposal of file system resources is required, the try-with-resources
      * construct should be used to ensure that the stream's
@@ -47,7 +47,7 @@ public class StreamCSV {
     }
 
     /**
-     * '{@link Stream}<{@link CsvRow}>' <b>must be closed with 'try'-with-resources statement</b>
+     * {@code Stream<CsvRow>} <b>must be closed with a try-with-resources statement.</b>
      * <p> The returned stream encapsulates a {@link Reader}.  If timely
      * disposal of file system resources is required, the try-with-resources
      * construct should be used to ensure that the stream's
@@ -66,7 +66,7 @@ public class StreamCSV {
     }
 
     /**
-     * '{@link Stream}<{@link CsvRow}>' <b>must be closed with 'try'-with-resources statement</b>
+     * {@code Stream<CsvRow>} <b>must be closed with a try-with-resources statement.</b>
      * <p> The returned stream encapsulates a {@link Reader}.  If timely
      * disposal of file system resources is required, the try-with-resources
      * construct should be used to ensure that the stream's
@@ -86,7 +86,7 @@ public class StreamCSV {
     }
 
     /**
-     * '{@link Stream}<{@link CsvRow}>' <b>must be closed with 'try'-with-resources statement</b>
+     * {@code Stream<CsvRow>} <b>must be closed with a try-with-resources statement.</b>
      * <p> The returned stream encapsulates a {@link Reader}.  If timely
      * disposal of file system resources is required, the try-with-resources
      * construct should be used to ensure that the stream's


### PR DESCRIPTION
Keep the standardized normal build annotation-free.