### PR TITLE
ci: pin Java workflows

### DIFF
--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -22,7 +22,7 @@ jobs:
   release:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@566f0d53a73c79d36616be7dcf6e05d9828d380b
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@6da5dd7ce18e43cd1de0aa721037b0da1a9d28cd
     with:
       semver_strategy: snapshot
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.maven_central != true }}
@@ -35,7 +35,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@566f0d53a73c79d36616be7dcf6e05d9828d380b
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@6da5dd7ce18e43cd1de0aa721037b0da1a9d28cd
     secrets:
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,6 +26,6 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@566f0d53a73c79d36616be7dcf6e05d9828d380b
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@6da5dd7ce18e43cd1de0aa721037b0da1a9d28cd
     with:
       ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -19,6 +19,6 @@ jobs:
       actions: write
       contents: write
       pull-requests: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_update_maven_wrapper.yml@566f0d53a73c79d36616be7dcf6e05d9828d380b
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_update_maven_wrapper.yml@6da5dd7ce18e43cd1de0aa721037b0da1a9d28cd
     with:
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
   release:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@566f0d53a73c79d36616be7dcf6e05d9828d380b
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@6da5dd7ce18e43cd1de0aa721037b0da1a9d28cd
     with:
       force: ${{ inputs.force }}
       dry_run: ${{ inputs.maven_central != true }}
@@ -34,7 +34,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@566f0d53a73c79d36616be7dcf6e05d9828d380b
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@6da5dd7ce18e43cd1de0aa721037b0da1a9d28cd
     secrets:
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
@@ -49,7 +49,7 @@ jobs:
     permissions:
       actions: read
       contents: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@566f0d53a73c79d36616be7dcf6e05d9828d380b
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@6da5dd7ce18e43cd1de0aa721037b0da1a9d28cd
     with:
       commit_sha: ${{ needs.release.outputs.commit_sha }}
       version: ${{ needs.release.outputs.version }}


### PR DESCRIPTION
Pin shared Java workflows to the current release-asset policy.