### PR TITLE
ci: guard date releases

### DIFF
--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -27,7 +27,7 @@ jobs:
   release:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@c5af554b4e859b238b7b65f9865bb84b51f7db54
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@e1933cd497e5c74457f62bf6996711603555c041
     with:
       semver_strategy: snapshot
       dry_run: ${{ github.event_name == 'workflow_dispatch' && (inputs.maven_central != true || inputs.github_packages != true) }}
@@ -40,7 +40,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@c5af554b4e859b238b7b65f9865bb84b51f7db54
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@e1933cd497e5c74457f62bf6996711603555c041
     secrets:
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
@@ -56,4 +56,4 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@c5af554b4e859b238b7b65f9865bb84b51f7db54
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@e1933cd497e5c74457f62bf6996711603555c041

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,6 +26,6 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@c5af554b4e859b238b7b65f9865bb84b51f7db54
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@e1933cd497e5c74457f62bf6996711603555c041
     with:
       ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -19,6 +19,6 @@ jobs:
       actions: write
       contents: write
       pull-requests: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_update_maven_wrapper.yml@c5af554b4e859b238b7b65f9865bb84b51f7db54
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_update_maven_wrapper.yml@e1933cd497e5c74457f62bf6996711603555c041
     with:
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
   release:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@c5af554b4e859b238b7b65f9865bb84b51f7db54
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@e1933cd497e5c74457f62bf6996711603555c041
     with:
       force: ${{ inputs.force }}
       dry_run: ${{ inputs.maven_central != true || inputs.github_packages != true }}
@@ -39,7 +39,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@c5af554b4e859b238b7b65f9865bb84b51f7db54
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@e1933cd497e5c74457f62bf6996711603555c041
     secrets:
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
@@ -55,7 +55,7 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@c5af554b4e859b238b7b65f9865bb84b51f7db54
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@e1933cd497e5c74457f62bf6996711603555c041
 
   github:
     needs:
@@ -66,7 +66,7 @@ jobs:
     permissions:
       actions: read
       contents: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@c5af554b4e859b238b7b65f9865bb84b51f7db54
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@e1933cd497e5c74457f62bf6996711603555c041
     with:
       commit_sha: ${{ needs.release.outputs.commit_sha }}
       version: ${{ needs.release.outputs.version }}


### PR DESCRIPTION
Pin the reusable guard that turns non-increasing date releases into snapshots.